### PR TITLE
Update Release CI to use Python 3.11 only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           path: obsidian-docs
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.x
+          python-version: 3.11
       - run: pip install -r requirements.txt
       - name: Copy Vault Content Over
         run: mv obsidian-docs/* docs/


### PR DESCRIPTION
Avoiding the issue of the following:

```
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [54 lines of output]
      running egg_info
      writing lib/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/opt/hostedtoolcache/Python/3.12.0/x64/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/opt/hostedtoolcache/Python/3.12.0/x64/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])

```